### PR TITLE
Add lobby-creation feature & rune-sending

### DIFF
--- a/champselect.py
+++ b/champselect.py
@@ -17,13 +17,10 @@ def ban_or_pick(connection: c.Connection) -> None:
     # User's turn to ban
     elif is_currently_banning(connection):
         ban_champ(connection)
-        # Re-hover pick intent after the ban
-        hover_champ(connection)
-        return
 
-    # Not user's turn to do anything, but still make sure we're always showing our intent
-    else:
-        hover_champ(connection)
+    # Ensure that we're always hovering the champ
+    hover_champ(connection)
+
 
 def hover_champ(connection: c.Connection, champid: int | None = None) -> None:
     """
@@ -133,7 +130,7 @@ def wait_before_locking(connection: c.Connection, action: ChampselectAction) -> 
         time.sleep(1)
 
         # Check if enough time elapsed
-        if time.time() > start_time + connection.lock_in_delay:
+        if time.time() > start_time + connection.lock_in_delay - 1:
             still_waiting = False
 
         # Make sure we update the hover if champ is changed by web API
@@ -229,7 +226,6 @@ def get_actionid(connection: c.Connection, mode: str) -> int | None:
 
     except Exception as e:
         warnings.warn(f"Unable to {mode} the specified champion: {e}", RuntimeWarning)
-        return
 
 
 def get_champselect_phase(connection: c.Connection) -> str:

--- a/champselect_action.py
+++ b/champselect_action.py
@@ -9,6 +9,8 @@ class ChampselectAction:
         self.actionid: int = actionid
         self.champid: int = champid
 
+    # Context manager to change the Action's mode to hover, then change it back when exiting.
+    # Used to ensure that client is hovering the champ before picking/banning.
     def __enter__(self):
         self._mode = "hover"
         return self

--- a/connect.py
+++ b/connect.py
@@ -260,27 +260,27 @@ class Connection:
     # -----------
     # API Methods
     # -----------
-    def api_get(self, endpoint: str) -> requests.Response:
+    def api_get(self, endpoint: str, should_print: bool = False) -> requests.Response:
         """ Send an HTTP GET request. """
-        return self.api_call(endpoint, "get")
+        return self.api_call(endpoint, "get", None, should_print)
 
 
-    def api_post(self, endpoint: str, data: dict | None = None) -> requests.Response:
+    def api_post(self, endpoint: str, data: dict | None = None, should_print: bool = False) -> requests.Response:
         """ Send an HTTP POST request. """
-        return self.api_call(endpoint, "post", data=data)
+        return self.api_call(endpoint, "post", data, should_print)
 
 
-    def api_put(self, endpoint: str, data: dict | None = None) -> requests.Response:
+    def api_put(self, endpoint: str, data: dict | None = None, should_print: bool = False) -> requests.Response:
         """ Send an HTTP PUT request. """
-        return self.api_call(endpoint, "put", data=data)
+        return self.api_call(endpoint, "put", data, should_print)
 
 
-    def api_patch(self, endpoint: str, data: dict | None = None) -> requests.Response:
+    def api_patch(self, endpoint: str, data: dict | None = None, should_print: bool = False) -> requests.Response:
         """ Send an HTTP PATCH request. """
-        return self.api_call(endpoint, "patch", data=data)
+        return self.api_call(endpoint, "patch", data, should_print)
 
 
-    def api_call(self, endpoint: str, method: str, data: dict | None = None, should_print: bool = False) -> requests.Response:
+    def api_call(self, endpoint: str, method: str, data: dict | None, should_print: bool) -> requests.Response:
         """
         Make an API call.
         Args:

--- a/formatting.py
+++ b/formatting.py
@@ -82,9 +82,66 @@ def clean_string(string: str) -> str:
 def champ(name: str) -> str:
     """ Format a champion name for user-facing display. """
     # This method is intended to be used only for display to the user; clean_name is used internally
-    # TODO: Implement this (and then actually use it)
-    # for now just capitalize it
-    return capitalize(name)
+    # There may be an endpoint provided by the LCU API for this, but this is good enough (for now ?).
+    name = capitalize(name)
+    match name:
+        case "Belveth" | "Kaisa" | "Reksai" | "Kogmaw", "Velkoz":
+            return format_void_champ(name)
+
+        case "Nunu":
+            return "Nunu and Willump"
+
+        case "Monkeyking":
+            return "Wukong"
+
+        case "Twistedfate":
+            return "Twisted Fate"
+
+        case "Xinzhao":
+            return "Xin Zhao"
+
+        case "Leblanc":
+            return "LeBlanc"
+
+        case "Masteryi":
+            return "Master Yi"
+
+        case "Missfortune":
+            return "Miss Fortune"
+
+        case "Drmundo":
+            return "Dr. Mundo"
+
+        case "Jarvaniv":
+            return "Jarvan IV"
+
+        case "Leesin":
+            return "Lee Sin"
+
+        case "Aurelionsol":
+            return "Aurelion Sol"
+
+        case "Tahmkench":
+            return "Tahm Kench"
+
+        case "Neeko":
+            return "Not Neeko"
+
+        case "Ksante":
+            return "K'Sante"
+
+        case _:
+            return name
+
+
+def format_void_champ(name: str) -> str:
+    """
+    Format the specified void champion's name for user-facing display.
+    Examples:
+        - Belveth -> Bel'Veth
+        - Kaisa -> Kai'Sa
+    """
+    return f"{name[:3]}'{name[3:]}"
 
 
 def capitalize(string: str) -> str:

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -7,11 +7,15 @@
 async function apiCall(endpoint, method, data) {
     let fullEndpoint = "http://127.0.0.1:5000/" + endpoint;
 
-    return await (await fetch(fullEndpoint, {
-        method: method,
-        headers: {"Content-Type": "application/json"},
-        body: JSON.stringify(data)
-    })).json()
+    try {
+        return await (await fetch(fullEndpoint, {
+            method: method,
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify(data)
+        })).json()
+    } catch (error) {
+        console.log(`Error while trying to send the request to endpoint ${endpoint}:\n\t${error}`)
+    }
 }
 
 /**
@@ -19,8 +23,8 @@ async function apiCall(endpoint, method, data) {
  * @param endpoint the endpoint to send the request to
  * @param data (optional) the data to send with the request
  */
-async function post(endpoint) {
-    return await apiCall(endpoint, "POST")
+async function post(endpoint, data) {
+    return await apiCall(endpoint, "POST", data)
 }
 
 /**
@@ -168,7 +172,7 @@ async function updateStatus() {
 async function scriptIsRunning() {
     try {
         let response = await get('status');
-        return response['success'];
+        return response['data'];
     } catch (error) {
         console.log(`Script not running due to an error: ${error}`)
         return false;

--- a/frontend/interface.js
+++ b/frontend/interface.js
@@ -50,9 +50,24 @@ function setUpBanInput() {
 
 function setUpRuneCheckbox() {
     // Allow the user to enable or disable rune changing
-    runeCheckbox.addEventListener("change", (event) => {
+    runeCheckbox.addEventListener("change", async (event) => {
+        event.preventDefault();
+
         // TODO: Log error message here instad of discarding
         void setRunesPreference(event.target.checked);
+
+        if (! event.target.checked) {
+            return;
+        }
+        // Send runes to the client if we're in champselect
+        if (await getGamestate() === "Champselect") {
+            let response = await post("actions/sendrunes");
+            if (response['success']) {
+                console.log("Successfully set runes!");
+            } else {
+                console.log(`Unable to set runes due to an error: ${response['statusText']}`);
+            }
+        }
     });
 }
 
@@ -69,6 +84,19 @@ function setUpQueueButton() {
     });
 }
 
+function setUpLobbyControls() {
+    lobbyButton.addEventListener("click", async (event) => {
+        event.preventDefault();
+
+        let response = await post("actions/createlobby", {lobbytype: lobbyDropdown.value});
+        if (response['success']) {
+            console.log("Successfully created a lobby!");
+        } else {
+            console.log(`Unable to create lobby due to an error: ${response['statusText']}`);
+        }
+    });
+}
+
 /**
  * Set up elements for the HTML display.
  */
@@ -78,4 +106,5 @@ function setUpDisplay() {
     setUpBanInput();
     setUpRuneCheckbox();
     setUpQueueButton();
+    setUpLobbyControls();
 }

--- a/frontend/page.html
+++ b/frontend/page.html
@@ -29,12 +29,23 @@
             <input type="checkbox" id="setrunes"> <br>
             <div style="padding-bottom: 8px"> </div>
 
+            <!-- Lobby management -->
+            <label for="lobbyDropdown">Select lobby type:</label>
+            <select name="lobbyDropdown" id="lobbyDropdown">
+                <option value="draft">Normal Draft</option>
+                <option value="ranked">Ranked Solo/Duo</option>
+                <option value="flex">Ranked Flex</option>
+            </select>
+            <div style="padding-bottom: 8px"> </div>
+            <button id="lobbyButton"> Create lobby </button>
+            <button id="queuebutton"> Start queue </button>
+            <div style="padding-bottom: 8px"> </div>
+
             <!-- Script status -->
             <label for="scriptstatus"> Script status:&nbsp </label>
             <label id="scriptstatus"> Not running </label> <br>
-            <div style="padding-bottom: 3px"> </div>
+            <div style="padding-bottom: 8px"> </div>
             <button id="startbutton"> Start script </button>
-            <button id="queuebutton"> Start queue </button>
         </form>
     </body>
 
@@ -47,8 +58,8 @@
         let banInput = document.getElementById("ban-intent-input");
         let runeCheckbox = document.getElementById("setrunes");
         let queueButton = document.getElementById("queuebutton");
-        // TODO: Add button to start queue
-        // TODO: Make rune checkbox send runes right away if enabled in finalization phase
+        let lobbyDropdown = document.getElementById("lobbyDropdown");
+        let lobbyButton = document.getElementById("lobbyButton");
 
         // Set up displays
         let pickDisplay = document.getElementById("pick-intent");

--- a/lobby.py
+++ b/lobby.py
@@ -10,6 +10,24 @@ def accept_match(connection: c.Connection) -> None:
     connection.api_post("accept_match")
 
 
+def create_lobby(connection: c.Connection, lobbytype: str) -> None:
+    """ Create a lobby for the specified gamemode. """
+    lobbyid: int
+    match lobbytype:
+        case "draft":
+            lobbyid = 400
+        case "ranked":
+            lobbyid = 420
+        case "flex":
+            lobbyid = 440
+        case "aram":
+            lobbyid = 450
+        case "arena":
+            lobbyid = 1700
+        case _:
+            raise RuntimeError(f"invalid lobby type: {lobbytype}")
+    response = connection.api_post('lobby', {'queueId': lobbyid})
+
 def reset_after_dodge(connection: c.Connection) -> None:
     """ Reset class instance variables after someone dodges a lobby. """
     connection.has_picked = False

--- a/runes.py
+++ b/runes.py
@@ -1,3 +1,4 @@
+import champselect
 import utility as u
 import connect as c
 import formatting
@@ -34,14 +35,22 @@ def send_runes_and_summs(connection: c.Connection) -> None:
         connection.api_patch("send_summs", request_body)
     connection.runes_chosen = True
 
-def build_runepage_request(connection) -> tuple[dict, list[int]]:
+def build_runepage_request(connection: c.Connection) -> tuple[dict, list[int]]:
     """
     Build an HTTP request body for setting the user's rune page and summoner spells.
     Returns:
         a tuple containing the HTTP request (dictionary), and a list of summoner spell IDs.
     """
-    champid: int = connection.api_get("current_champ").json()
-    champ_name: str = connection.get_champ_name_by_id(champid)
+    # Check pick intent if we haven't locked yet
+    if connection.get_gamestate() == "ChampSelect":
+        champ_name: str = connection.pick_intent
+        champid: int = connection.get_champid(champ_name)
+
+    # If we already locked in, check what champ was locked using API (in case user picks something besides pick intent)
+    else:
+        champid: int = connection.api_get("current_champ").json()  # this endpoint only works after locking
+        champ_name = connection.get_champ_name_by_id(champid)
+
     role_name: str = connection.get_assigned_role()
 
     # Get the runepage to use

--- a/test.py
+++ b/test.py
@@ -1,9 +1,8 @@
 import connect
+import lobby
 
 c = connect.Connection()
 
 c.populate_champ_table()
 
-c.update_primary_role()
-
-print(c.user_role)
+lobby.create_lobby(c, "draft")

--- a/update.py
+++ b/update.py
@@ -6,7 +6,7 @@ import os
 
 owner: str = "jacob2467"
 repo: str = "champselect-2.0"
-branch: str = "main"
+branch: str = "electron"
 version_file: str = "version.txt"
 update_zip: str = "update.zip"
 

--- a/webapp.py
+++ b/webapp.py
@@ -9,6 +9,7 @@ import champselect
 import formatting
 import main_loop
 import lobby
+import runes
 
 # TODO: make the script queue the mode you select and also make a button to start each queue
 
@@ -150,10 +151,10 @@ def get_status():
         )
 
     return build_response(
-        success=False,
+        success=True,
         statusText="Script is not running.",
         data=False,
-        status=400,
+        status=200,
     )
 
 
@@ -279,6 +280,37 @@ def set_runes_preference():
         return build_response(
             success=False,
             statusText=statusText,
+            status=400
+        )
+
+
+@api.route("/actions/sendrunes", methods=["POST"])
+@ensure_connection
+def set_runes():
+    try:
+        runes.send_runes_and_summs(state.connection)
+        return empty_success_response()
+    except Exception as e:
+        return build_response(
+            success=False,
+            statusText=f"Unable to set runes due to an error: {e}",
+            status=400
+        )
+
+
+
+@api.route("/actions/createlobby", methods=["POST"])
+@ensure_connection
+def create_lobby():
+    lobbytype = flask.request.json['lobbytype']
+    try:
+        lobby.create_lobby(state.connection, lobbytype)
+        return empty_success_response()
+
+    except Exception as e:
+        return build_response(
+            success=False,
+            statusText=f"Unable to create the lobby due to an error: {e}",
             status=400
         )
 


### PR DESCRIPTION
Added functions to create a lobby (currently supports draft, ranked solo/duo, and ranked flex), and the appropriate JS/HTML buttons and functions to access them. Also made it so that runes are sent to the client right away when the user clicks the rune checkbox on during champselect. Finally, implemented function for user-facing chamion name formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lobby creation with selectable game types (Normal Draft, Ranked Solo/Duo, Ranked Flex)
  * Added rune submission functionality for champion selection
  * Enhanced error handling in API communication with improved logging

* **Bug Fixes**
  * Fixed status endpoint response when script is not running

* **Chores**
  * Updated default branch for application updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->